### PR TITLE
feat: add URL-only option for playlist output

### DIFF
--- a/src/components/Results.jsx
+++ b/src/components/Results.jsx
@@ -15,6 +15,7 @@ const Results = ({ list }) => {
   const [regexFilter, setRegexFilter] = useState("");
   const [negateRegex, setNegateRegex] = useState(false);
   const [showDuration, setShowDuration] = useState(false);
+  const [urlOnly, setUrlOnly] = useState(false);
 
   const videoDurations = useVideoDurations(list);
   const processedList = useProcessedList(list, {
@@ -35,6 +36,7 @@ const Results = ({ list }) => {
       customPrefix,
       ProgrammingBrackets,
       videoDurations,
+      urlOnly,
     });
   };
 
@@ -147,6 +149,11 @@ const Results = ({ list }) => {
                   label: "Show Duration",
                   state: showDuration,
                   setState: setShowDuration,
+                },
+                {
+                  label: "URLs only",
+                  state: urlOnly,
+                  setState: setUrlOnly,
                 },
               ].map(({ label, state, setState }) => (
                 <label key={label} className="flex items-center cursor-pointer">

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -52,12 +52,19 @@ export const formatList = (processedList, options) => {
     customPrefix = "",
     ProgrammingBrackets = "[]",
     videoDurations = {},
+    urlOnly = false,
   } = options;
 
   const baseItems = processedList.map((l) => {
-    const { title, resourceId } = l.snippet;
+    const { resourceId } = l.snippet;
     const videoId = resourceId.videoId;
     const url = `https://www.youtube.com/watch?v=${videoId}`;
+
+    if (urlOnly) {
+      return url;
+    }
+
+    const { title } = l.snippet;
     const duration = videoDurations[videoId] || "PT0M0S";
     const formattedDuration = showDuration ? formatDuration(duration) : "";
 


### PR DESCRIPTION
Fixes #1

Added URL-only option that allows users to:
- Get clean URLs only using a new checkbox option
- Maintain compatibility with existing formatting options (bullets, numbers, etc.)
- Copy just the video URLs without any additional information