### PR TITLE
feat: Add video duration and channel name to list format with improved readability #3

### DIFF
--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -33,13 +33,10 @@ const Input = ({ handleUrlChange, handlePlaylistInfo, playListInfo }) => {
   const getPlaylistData = async (nextPageToken, ct = 0) => {
     try {
       setIsLoading(true);
-      const url = `https://www.googleapis.com/youtube/v3/playlistItems?playlistId=${
-        text.split("=")[1]
-      }&key=${
-        import.meta.env.VITE_YOUTUBE_API_KEY
-      }&maxResults=50&part=snippet,id${
-        nextPageToken ? `&pageToken=${nextPageToken}` : ""
-      }`;
+      const url = `https://www.googleapis.com/youtube/v3/playlistItems?playlistId=${text.split("=")[1]
+        }&key=${import.meta.env.VITE_YOUTUBE_API_KEY
+        }&maxResults=50&part=snippet,id${nextPageToken ? `&pageToken=${nextPageToken}` : ""
+        }`;
 
       const response = await axios.get(url);
       const playlistData = response?.data.items;
@@ -65,9 +62,8 @@ const Input = ({ handleUrlChange, handlePlaylistInfo, playListInfo }) => {
 
   return (
     <div
-      className={`flex flex-col items-center px-4 transition-all duration-500 ease-in-out ${
-        isTop ? "mt-12" : "mt-[30vh]"
-      }`}
+      className={`flex flex-col items-center px-4 transition-all duration-500 ease-in-out ${isTop ? "mt-12" : "mt-[30vh]"
+        }`}
     >
       <div className="w-full max-w-2xl">
         <div className="relative">
@@ -76,11 +72,10 @@ const Input = ({ handleUrlChange, handlePlaylistInfo, playListInfo }) => {
             value={text}
             placeholder="Paste YouTube Playlist URL"
             onChange={handleChange}
-            className={`w-full px-6 py-4 text-lg text-gray-800 bg-white border-2 rounded-full focus:outline-none focus:ring-2 transition-all duration-300 ${
-              !playlistRegex.test(text)
-                ? "focus:ring-red-300 border-red-300"
-                : "focus:ring-indigo-300 border-indigo-300"
-            } shadow-md hover:shadow-lg`}
+            className={`w-full px-6 py-4 text-lg text-gray-800 bg-white border-2 rounded-full focus:outline-none focus:ring-2 transition-all duration-300 ${!playlistRegex.test(text)
+              ? "focus:ring-red-300 border-red-300"
+              : "focus:ring-indigo-300 border-indigo-300"
+              } shadow-md hover:shadow-lg`}
           />
           <button
             onClick={() => {
@@ -120,9 +115,8 @@ const Input = ({ handleUrlChange, handlePlaylistInfo, playListInfo }) => {
           </button>
         </div>
         <div
-          className={`mt-4 text-center transition-all duration-300 ${
-            error ? "text-red-500" : "text-gray-600"
-          }`}
+          className={`mt-4 text-center transition-all duration-300 ${error ? "text-red-500" : "text-gray-600"
+            }`}
         >
           {!playlistRegex.test(text) ? (
             <p className="text-sm">

--- a/src/components/Results.jsx
+++ b/src/components/Results.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import toast from "react-hot-toast";
-import { useVideoDurations } from "../hooks/useVideoDurations";
+import { useVideoDetails } from "../hooks/useVideoDurations";
 import { useProcessedList } from "../hooks/useProcessedList";
 import { formatList } from "../utils/formatters";
 
@@ -16,8 +16,9 @@ const Results = ({ list }) => {
   const [negateRegex, setNegateRegex] = useState(false);
   const [showDuration, setShowDuration] = useState(false);
   const [urlOnly, setUrlOnly] = useState(false);
+  const [showChannelName, setShowChannelName] = useState(true);
 
-  const videoDurations = useVideoDurations(list);
+  const videoDetails = useVideoDetails(list);
   const processedList = useProcessedList(list, {
     checkedRemovePriv,
     checkedRemoveDuplicates,
@@ -35,8 +36,9 @@ const Results = ({ list }) => {
       listType,
       customPrefix,
       ProgrammingBrackets,
-      videoDurations,
+      videoDetails,
       urlOnly,
+      showChannelName,
     });
   };
 
@@ -86,16 +88,16 @@ const Results = ({ list }) => {
                       listType === "numbered"
                         ? "1. "
                         : listType === "bulleted"
-                        ? "- "
-                        : "Enter prefix"
+                          ? "- "
+                          : "Enter prefix"
                     }
                   />
                   <p className="mt-1 text-sm text-gray-500">
                     {listType === "numbered"
                       ? "Will be prepended to the number, e.g. 'Chapter 1. '"
                       : listType === "bulleted"
-                      ? "Will replace the default bullet point"
-                      : "Will be prepended to each item"}
+                        ? "Will replace the default bullet point"
+                        : "Will be prepended to each item"}
                   </p>
                 </div>
               )}
@@ -149,6 +151,11 @@ const Results = ({ list }) => {
                   label: "Show Duration",
                   state: showDuration,
                   setState: setShowDuration,
+                },
+                {
+                  label: "Show Channel Name",
+                  state: showChannelName,
+                  setState: setShowChannelName,
                 },
                 {
                   label: "URLs only",

--- a/src/hooks/useVideoDurations.js
+++ b/src/hooks/useVideoDurations.js
@@ -1,41 +1,50 @@
 import { useState, useEffect } from "react";
 
-export const useVideoDurations = (list) => {
-  const [videoDurations, setVideoDurations] = useState({});
+export const useVideoDetails = (list) => {
+  const [videoDetails, setVideoDetails] = useState({});
 
   useEffect(() => {
-    const fetchDurations = async () => {
-      const videoIds = list.map((item) => item.snippet.resourceId.videoId);
+    const fetchDetails = async () => {
+      const videoIds = list
+        .filter(item => item?.snippet?.resourceId?.videoId)
+        .map((item) => item.snippet.resourceId.videoId);
+
+      if (videoIds.length === 0) {
+        return;
+      }
+
       const chunks = [];
       for (let i = 0; i < videoIds.length; i += 50) {
         chunks.push(videoIds.slice(i, i + 50));
       }
 
-      const durationsMap = {};
+      const detailsMap = {};
       for (const chunk of chunks) {
         try {
           const response = await fetch(
             `https://www.googleapis.com/youtube/v3/videos?` +
-              `id=${chunk.join(",")}&part=contentDetails&key=${
-                import.meta.env.VITE_YOUTUBE_API_KEY
-              }`
+            `id=${chunk.join(",")}&part=contentDetails,snippet&key=${import.meta.env.VITE_YOUTUBE_API_KEY
+            }`
           );
           const data = await response.json();
 
           data.items.forEach((item) => {
-            durationsMap[item.id] = item.contentDetails.duration;
+            detailsMap[item.id] = {
+              duration: item.contentDetails.duration,
+              channelTitle: item.snippet.channelTitle
+            };
           });
         } catch (error) {
-          console.error("Error fetching video durations:", error);
+          console.error("Error fetching video details:", error);
         }
       }
-      setVideoDurations(durationsMap);
+      setVideoDetails(detailsMap);
     };
 
     if (list.length > 0) {
-      fetchDurations();
+      fetchDetails();
     }
   }, [list]);
 
-  return videoDurations;
+  return videoDetails;
 };


### PR DESCRIPTION
Resolves #3
- #3

This PR adds the ability to display channel/uploader information for each video in the playlist, along with several formatting improvements:

Key Changes:
- Added channel name display with toggle option in the UI
- Fetch channel information directly from video metadata instead of playlist data
- Improved format to show duration and channel at the start: `[3:45] • [Channel Name] • Video Title`
- Added consistent separators (•) between elements for better readability
- Made channel display optional via checkbox in the Options section